### PR TITLE
Change "docker compose" typo to "docker-compose"

### DIFF
--- a/docs/getting-started/installation/docker/docker-compose.md
+++ b/docs/getting-started/installation/docker/docker-compose.md
@@ -1,9 +1,9 @@
-# Docker Compose
+# Docker-Compose
 
-You can run 2FAuth with [Docker Compose](https://docs.docker.com/compose/) using the following command and `docker-compose.yml` file:
+You can run 2FAuth with [Docker-Compose](https://docs.docker.com/compose/) using the following command and `docker-compose.yml` file:
 
 ```bash
-docker compose up
+docker-compose up
 ```
 
 :::code source="./../../../static/docker-compose.yml" title="`docker-compose.yml` (Environment variables are optional)" language="yaml":::


### PR DESCRIPTION
`Docker compose` is an invalid command in docker. `docker-compose` is the correct syntax.