### PR TITLE
Docker CLI doc has a wrong argument order

### DIFF
--- a/docs/getting-started/installation/docker/docker-cli.md
+++ b/docs/getting-started/installation/docker/docker-cli.md
@@ -56,8 +56,9 @@ We assume your current directory is `/yourpath`.
 
     ```sh
     docker run -it --rm -p 8000:8000/tcp \
-    -v /yourpath/2fauth:/2fauth 2fauth/2fauth
-    -e AUTHENTICATION_GUARD=web-guard
+    -v /yourpath/2fauth:/2fauth \
+    -e AUTHENTICATION_GUARD=web-guard \
+    2fauth/2fauth
     ```
 
 1. Access it in your browser


### PR DESCRIPTION
After reading https://github.com/Bubka/2FAuth/discussions/287#discussioncomment-8261041:

> DOES NOT WORK
> 
> > pi@pi5:~ $ sudo docker run -it --rm -p 8000:8000/tcp
> > -v /home/pi/2fauth:/2fauth 2fauth/2fauth
> > -e AUTHENTICATION_GUARD=web-guard
> > -e APP_URL=http://localhost:8000/
> > -e ASSET_URL=http://localhost:8000/
> 
> WORKS
> 
> > pi@pi5:~ $ sudo docker run -it --rm -p 8000:8000/tcp
> > -e AUTHENTICATION_GUARD=web-guard
> > -e APP_URL=http://localhost:8000/
> > -e ASSET_URL=http://localhost:8000/
> > -v /home/pi/2fauth:/2fauth 2fauth/2fauth

I went to check [the official Docker reference](https://docs.docker.com/engine/reference/commandline/container_run/):

> `docker container run [OPTIONS] IMAGE [COMMAND] [ARG...]`

so it turns out that `2fauth/2fauth` chunk is not part of options and should come after all of options, or otherwise those which come after it are not passed as valid options.