### PR TITLE
docker-cli: add command for generating `APP_KEY` locally

### DIFF
--- a/docs/getting-started/installation/docker/docker-cli.md
+++ b/docs/getting-started/installation/docker/docker-cli.md
@@ -61,7 +61,11 @@ We assume your current directory is `/yourpath`.
     ```
 
     !!!warning Mandatory env var
-    The [`APP_KEY`](/getting-started/config/env-vars/#app_key) environment variable must be set with a personal unique value. You can generate a brand new one using [Laravel Encryption Key Generator](https://laravel-encryption-key-generator.vercel.app/).  
+    The [`APP_KEY`](/getting-started/config/env-vars/#app_key) environment variable must be set with a personal unique value. You can generate a brand new one using [Laravel Encryption Key Generator](https://laravel-encryption-key-generator.vercel.app/).
+    Alternatively, you can use the `2fauth` container to generate a key locally:
+    ```sh
+    docker run -it --rm --entrypoint /usr/bin/php 2fauth/2fauth artisan key:generate --show
+    ```
 
     If you need to rotate the key, use the [`APP_PREVIOUS_KEYS`](/getting-started/config/env-vars/#app_previous_keys) environment variable to list previous keys and avoid decryption issues or invalid access tokens.
     !!!


### PR DESCRIPTION
The docker CLI set-up guide suggests generating a new application key using a web service. This change adds instructions to generate `APP_KEY` locally, using the 2fauth container - which may be preferable for security reasons.